### PR TITLE
Scalajs 1.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
 
 env:
   - SCALAJS_VERSION=
-  - SCALAJS_VERSION=1.0.0-RC2
+  - SCALAJS_VERSION=1.0.1
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,14 @@ scala:
 jdk:
   - openjdk8
 
+env:
+  - TARGET=JVM
+  - TARGET=JS
+  - SCALAJS_VERSION=1.0.0-RC2 TARGET=JVM
+  - SCALAJS_VERSION=1.0.0-RC2 TARGET=JS
+
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION test
+  - sbt ++$TRAVIS_SCALA_VERSION ${TARGET}/test
 
 before_cache:
   - rm -f $HOME/.ivy2/.sbt.ivy.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,10 @@ cache:
     - $HOME/.coursier
     - $HOME/.ivy2/cache
     - $HOME/.sbt
+
+install:
+  - . $HOME/.nvm/nvm.sh
+  - nvm install stable
+  - nvm use stable
+  - npm install
+  - npm install jsdom

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,11 @@ jdk:
   - openjdk8
 
 env:
-  - TARGET=JVM
-  - TARGET=JS
-  - SCALAJS_VERSION=1.0.0-RC2 TARGET=JVM
-  - SCALAJS_VERSION=1.0.0-RC2 TARGET=JS
+  - SCALAJS_VERSION=
+  - SCALAJS_VERSION=1.0.0-RC2
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION ${TARGET}/test
+  - sbt ++$TRAVIS_SCALA_VERSION test
 
 before_cache:
   - rm -f $HOME/.ivy2/.sbt.ivy.lock

--- a/gen/shared/src/main/scala/nyaya/gen/Distinct.scala
+++ b/gen/shared/src/main/scala/nyaya/gen/Distinct.scala
@@ -9,6 +9,7 @@ import Baggy._
 import Baggy.Implicits._
 import Distinct.{Fixer, foldableList}
 import scala.collection.compat._
+import shims._
 
 sealed trait DistinctFn[A, B] {
   def run: A => B

--- a/gen/shared/src/main/scala/nyaya/gen/Distinct.scala
+++ b/gen/shared/src/main/scala/nyaya/gen/Distinct.scala
@@ -9,7 +9,6 @@ import Baggy._
 import Baggy.Implicits._
 import Distinct.{Fixer, foldableList}
 import scala.collection.compat._
-import shims._
 
 sealed trait DistinctFn[A, B] {
   def run: A => B

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -4,13 +4,13 @@ import com.typesafe.sbt.pgp.PgpKeys
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import org.scalajs.sbtplugin.ScalaJSPlugin
 import pl.project13.scala.sbt.JmhPlugin
-import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType, _}
 import sbtrelease.ReleasePlugin.autoImport._
 import scalajscrossproject.ScalaJSCrossPlugin.autoImport._
 import ScalaJSPlugin.autoImport._
 import Lib._
 
 object NyayaBuild {
+  import sbtcrossproject.CrossPlugin.autoImport._
 
   private val ghProject = "nyaya"
 
@@ -21,7 +21,7 @@ object NyayaBuild {
     val BetterMonadicFor = "0.3.1"
     val KindProjector    = "0.11.0"
     val Monocle          = "1.6.0"
-    val MTest            = "0.6.9"
+    val MTest            = "0.7.3"
     val Scala212         = "2.12.11"
     val Scala213         = "2.13.1"
     val ScalaCollCompat  = "2.1.6"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,6 +6,7 @@ import org.scalajs.sbtplugin.ScalaJSPlugin
 import pl.project13.scala.sbt.JmhPlugin
 import sbtrelease.ReleasePlugin.autoImport._
 import scalajscrossproject.ScalaJSCrossPlugin.autoImport._
+import org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 import ScalaJSPlugin.autoImport._
 import Lib._
 
@@ -21,11 +22,12 @@ object NyayaBuild {
     val BetterMonadicFor = "0.3.1"
     val KindProjector    = "0.11.0"
     val Monocle          = "1.6.0"
-    val MTest            = "0.7.3"
+    val MTest            = "0.7.4"
     val Scala212         = "2.12.11"
     val Scala213         = "2.13.1"
     val ScalaCollCompat  = "2.1.6"
     val Scalaz           = "7.2.30"
+    val Shims            = "2.1-b291d9c-SNAPSHOT"
   }
 
   def scalacFlags = Seq(
@@ -68,7 +70,7 @@ object NyayaBuild {
       testFrameworks      += new TestFramework("utest.runner.Framework")))
     .jsConfigure(
       // Not mandatory; just faster.
-      _.settings(jsEnv in Test := PhantomJSEnv().value))
+      _.settings(jsEnv in Test := new JSDOMNodeJSEnv()))
 
 
   // ==============================================================================================

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,7 +27,7 @@ object NyayaBuild {
     val Scala213         = "2.13.1"
     val ScalaCollCompat  = "2.1.6"
     val Scalaz           = "7.2.30"
-    val Shims            = "2.1-b291d9c-SNAPSHOT"
+    val Shims            = "2.0.0"
   }
 
   def scalacFlags = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,13 +21,12 @@ object NyayaBuild {
   object Ver {
     val BetterMonadicFor = "0.3.1"
     val KindProjector    = "0.11.0"
-    val Monocle          = "1.6.0"
+    val Monocle          = "1.6.3"
     val MTest            = "0.7.4"
     val Scala212         = "2.12.11"
     val Scala213         = "2.13.1"
     val ScalaCollCompat  = "2.1.6"
     val Scalaz           = "7.2.30"
-    val Shims            = "2.0.0"
   }
 
   def scalacFlags = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.31")
+  Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("0.6.31")
 
 addSbtPlugin("com.github.gseitz"  % "sbt-release"              % "1.0.13")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "1.1.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("0.6.31")
+  Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("0.6.32")
 
 addSbtPlugin("com.github.gseitz"  % "sbt-release"              % "1.0.13")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "1.1.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,8 @@
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.31")
+
 addSbtPlugin("com.github.gseitz"  % "sbt-release"              % "1.0.13")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "1.1.2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.32")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % scalaJSVersion)
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                  % "0.3.7")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,8 @@ addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "1.1.2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % scalaJSVersion)
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"                  % "0.3.7")
+
+libraryDependencies ++= {
+  if (scalaJSVersion.startsWith("0.6.")) Nil
+  else Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0-RC3")
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,5 +9,5 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh"                  % "0.3.7")
 
 libraryDependencies ++= {
   if (scalaJSVersion.startsWith("0.6.")) Nil
-  else Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0-RC3")
+  else Seq("org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.0.0")
 }


### PR DESCRIPTION
Supersedes https://github.com/japgolly/nyaya/pull/77

Monocle since 2.0.0 is cats based. So, to unify typeclasses I dragged `shims`.

Shims is not ready for Scala.js 1 yet. Created MR: https://github.com/djspiewak/shims/pull/85